### PR TITLE
Generate changes entries from special files

### DIFF
--- a/download_files
+++ b/download_files
@@ -11,6 +11,9 @@
 DORECOMPRESS=""
 ENFORCELOCAL=""
 ENFORCEUPSTREAM=""
+CHANGES_GENERATE=disable
+CHANGES_AUTHOR=""
+CHANGES_LINES_MAX=30
 while test $# -gt 0; do
   case $1 in
     *-recompress)
@@ -33,6 +36,18 @@ while test $# -gt 0; do
     ;;
     *-outdir)
       MYOUTDIR="$2"
+      shift
+    ;;
+    *-changesgenerate)
+      CHANGES_GENERATE="$2"
+      shift
+    ;;
+    *-changesauthor)
+      CHANGES_AUTHOR="$2"
+      shift
+    ;;
+    *-changeslinesmax)
+      CHANGES_LINES_MAX="$2"
       shift
     ;;
     *)
@@ -73,6 +88,48 @@ function uncompress_file() {
   echo $basename
 }
 
+function write_changes() {
+  spec_file_name=$1
+
+  if [ "$spec_file_name" = "PKGBUILD" ] ; then
+    echo "No support for writing PKGBUILD changes"
+    return
+  fi
+  if [ ${#CHANGES_LINES[@]} -eq 0 ] ; then
+    echo "No changes since $CHANGES_REVISION, skipping changes file generation"
+    return
+  fi
+
+  if [ -z "$CHANGES_AUTHOR" ] ; then
+    OSCRC="$HOME/.oscrc"
+    if [ -f $OSCRC ] ; then
+      CHANGES_AUTHOR=$(grep -e '^email.*=' $OSCRC | head -n1 | cut -d"=" -f2)
+    else
+      CHANGES_AUTHOR="opensuse-packaging@opensuse.org"
+    fi
+  fi
+
+  change_entry="-------------------------------------------------------------------
+$(LC_ALL=POSIX TZ=UTC date) - ${CHANGES_AUTHOR}
+
+- Update to version $NEW_VERSION:"
+  for change in "${CHANGES_LINES[@]}" ; do
+    # Skip some common boilerplate pattern:
+    case $change in
+      ==*|--*|CHANGES) continue ;;
+    esac
+    change_entry="$change_entry
+  $change"
+  done
+  change_entry="$change_entry
+"
+
+  # Prepend change entry to current changes file
+  changes_file="$SRCDIR/${spec_file_name%".spec"}.changes"
+  tmpfile=$(mktemp)
+  echo "$change_entry" | cat - $changes_file > $tmpfile && mv $tmpfile $MYOUTDIR/$(basename $changes_file)
+}
+
 
 default_config="/usr/lib/build/configs/sl12.3.conf"
 [ -e "/usr/lib/build/configs/default.conf" ] && default_config="/usr/lib/build/configs/default.conf"
@@ -101,6 +158,18 @@ for i in *.spec PKGBUILD; do
     # We do not tell the server that we are an OBS tool by default anymore,
     # because too many sites just have a white list, but they accept wget
     # WGET="$WGET -U 'OBS-wget'"
+
+
+    if [ "$CHANGES_GENERATE" == "enable" ]; then
+      # Check old tarball if there are any changes files present, take the first one (if any)
+      #changes_filename=$(tar -tf $BN* 2>/dev/null | sed -e "s|[^/]*/||" | grep -iE "changelog|news|changes" | head -n1)
+      OLD_CHANGES_FILENAME=$(tar -tf $BN* 2>/dev/null | grep -iE "/changelog|news|changes" | head -n1)
+      if [ -n "$OLD_CHANGES_FILENAME" ] ; then
+        OLD_CHANGES_FILE=$(tar -xvf $BN* $OLD_CHANGES_FILENAME)
+        OLD_CHANGES_BASEDIR=$(echo $OLD_CHANGES_FILE | sed -e "s|/.*||")
+      fi
+    fi
+    SRCDIR=$PWD
 
     cd "$MYOUTDIR"
 
@@ -143,6 +212,26 @@ for i in *.spec PKGBUILD; do
     if [[ -n "$MYCACHEDIRECTORY" && ! -f "$MYCACHEDIRECTORY/file/$HASH" ]]; then
       cp -a "$FILE" "$MYCACHEDIRECTORY/file/$HASH" && \
       echo "$FILE" > "$MYCACHEDIRECTORY/filename/$HASH"
+    fi
+
+    if [ "$CHANGES_GENERATE" == "enable" -a -n "$OLD_CHANGES_FILE" ]; then
+      # Try to find the same changes file in the new tarball
+      CHANGES_FILENAME=$(tar -tf $BN* 2>/dev/null | grep -iE "/changelog|news|changes" | head -n1)
+      if [ -n "$CHANGES_FILENAME" ] ; then
+        CHANGES_FILE=$(tar -xvf $BN* $CHANGES_FILENAME)
+        CHANGES_BASEDIR=$(echo $CHANGES_FILE | sed -e "s|/.*||")
+        NEW_VERSION=${CHANGES_BASEDIR#$BN-}  # Find out what version we updated to
+        # Check if both old and new aren't the same files:
+        if [ "$OLD_CHANGES_FILE" != "$CHANGES_FILE" ] ; then
+          lines=$(diff -u $SRCDIR/$OLD_CHANGES_FILE $CHANGES_FILE | grep -E "^\+.*" | grep -vE "^\+\+\+" | head -n $CHANGES_LINES_MAX | cut -d"+" -f2-)
+          OLD_IFS="$IFS"
+          IFS=$'\n' CHANGES_LINES=( $lines )
+          IFS="$OLD_IFS"
+          rm -rf $CHANGES_BASEDIR || :
+        fi
+      fi
+      rm -rf $SRCDIR/$OLD_CHANGES_BASEDIR || :
+      rm -rf $OLD_CHANGES_BASEDIR || :
     fi
 
     if [[ -n "$RECOMPRESS" ]]; then
@@ -201,6 +290,10 @@ for i in *.spec PKGBUILD; do
     elif [ -n "$ENFORCELOCAL" ]; then
       echo "ERROR: download_files is configured to fail when the file was not committed... this is the case!"
       exit 1
+    fi
+
+    if [ "$CHANGES_GENERATE" == "enable" ] ; then
+      write_changes $i
     fi
 
     cd - > /dev/null

--- a/download_files.service
+++ b/download_files.service
@@ -14,6 +14,16 @@
     <description>Fail when the file was not commited, download will happen anyway to verify that file is identical with upstream. Package state will become "broken".</description>
     <allowedvalue>yes</allowedvalue>
   </parameter>
-
+  <param name="changesgenerate">
+    <description>Whether or not to generate changes file entries from special files in the tarball (such as NEWS, CHANGES* or ChangeLog).  Default is 'disable'.</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </param>
+  <param name="changesauthor">
+    <description>The author of the changes file entry to be written, defaults to first email entry in ~/.oscrc or "opensuse-packaging@opensuse.org" if there is no .oscrc found.</description>
+  </param>
+  <param name="changeslinesmax">
+    <description>The maximum amount of changes lines that are written (the rest is dropped). Defaults to 30.</description>
+  </param>
 </service>
 


### PR DESCRIPTION
If the new flag 'changesgenerate' is set, tarballs are searched for files such as CHANGES(.txt), NEWS or ChangeLog. A diff is then generated between the old and new version of this file and written to the respective changes file.

Can be customized further by adjusting:
- changesauthor (does the right thing by default)
- changeslinesmax (30 by default)
