### PR TITLE
Stricter change filename check

### DIFF
--- a/download_files
+++ b/download_files
@@ -162,7 +162,7 @@ for i in *.spec PKGBUILD; do
 
     if [ "$CHANGES_GENERATE" == "enable" ]; then
       # Check old tarball if there are any changes files present, take the first one (if any)
-      #changes_filename=$(tar -tf $BN* 2>/dev/null | sed -e "s|[^/]*/||" | grep -iE "changelog|news|changes" | head -n1)
+      #changes_filename=$(tar -tf $BN* 2>/dev/null | sed -e "s|[^/]*/||" | grep -iE 'changelog$|news$|changes$' | head -n1)
       OLD_CHANGES_FILENAME=$(tar -tf $BN* 2>/dev/null | grep -iE "/changelog|news|changes" | head -n1)
       if [ -n "$OLD_CHANGES_FILENAME" ] ; then
         OLD_CHANGES_FILE=$(tar -xvf $BN* $OLD_CHANGES_FILENAME)


### PR DESCRIPTION
This fixes a problem when there's a filename which contains one of the
matchers in it's name (i.e. 'changes_foo_bar). Be more strict now and
check that the file at least ends with the match.