### PR TITLE
Report download failures

### DIFF
--- a/download_files
+++ b/download_files
@@ -15,7 +15,7 @@ CHANGES_GENERATE=disable
 CHANGES_AUTHOR=""
 CHANGES_LINES_MAX=30
 
-WGET="/usr/bin/wget --timeout=30 -q --tries=2 --no-directories"
+WGET="/usr/bin/wget --timeout=30 -nv --tries=2 --no-directories"
 # We do not tell the server that we are an OBS tool by default anymore,
 # because too many sites just have a white list, but they accept wget
 # WGET="$WGET -U 'OBS-wget'"
@@ -223,7 +223,6 @@ for i in *.spec PKGBUILD appimage.yml; do
   test -e "$i" || continue
 
   for url in `perl -I/usr/lib/build -MBuild -e Build::show $default_config "$i" sources` `perl -I/usr/lib/build -MBuild -e Build::show $default_config "$i" patches`; do
-   
     MYCACHEDIRECTORY="$CACHEDIRECTORY"
     PROTOCOL="${url%%:*}"
     SAMEFILEAFTERCOMPRESSION=


### PR DESCRIPTION
https://build.opensuse.org/request/show/404309 for example
was rejected by the bot scripts, but all it gave was a useless
message (i.e. without a reason as to _why_ it was unable to
download it):

ERROR: Failed to download "http://[...]/kid3-3.4.1.tar.gz"
Source URLs are not valid. Try "osc service localrun download_files"

More often than not, downloads fail because Sourceforge cannot
get its mirroring to be flawless.

Use -nv instead of -q so that the error reason is shown.

In addition, the use of -nv will cause local runs to emit success
progress report lines as well, quite useful if there are a lot of
source files in a SRPM (e.g. in case of asterisk-sounds).
