### PR TITLE
Add missing build-dependencies to d/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,13 @@ Source: obs-service-download-files
 Maintainer: Hib Eris <hib@hiberis.nl>
 Section: devel
 Priority: extra
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper (>= 7),
+ build | obs-build,
+ libcgi-pm-perl,
+ libfile-type-perl,
+ libhttp-server-simple-perl,
+ libpath-class-perl,
+ wget,
 Standards-Version: 3.9.6
 Homepage: https://github.com/openSUSE/obs-service-download_files
 


### PR DESCRIPTION
The unit tests need some perl modules and wget to run.
Add the missing build-dependencies to fix the build on Debian and
Ubuntu:
 libpath-class-perl, libhttp-server-simple-perl, libfile-type-perl,
 libcgi-pm-perl,  build | obs-build, wget