### PR TITLE
remove leftover partial file when wget fails

### DIFF
--- a/download_files
+++ b/download_files
@@ -244,6 +244,7 @@ for i in *.spec PKGBUILD; do
     elif [ -z "$DORECOMPRESS" ]; then
       FILE="${url##*/}"
       if ! $WGET "$url$urlextension" -O "$FILE"; then
+        rm -f "$FILE"
         echo "ERROR: Failed to download \"$url\""
         exit 1
       fi


### PR DESCRIPTION
When wget fails, it still opens the output file, which will be left as at least a 0-byte file. On OBS, this can lead to "successfully" built RPMs with 0-byte files if the SOURCE files are not unpacked but just copied to their final location. Instead, remove whatever file is left over.