### PR TITLE
Don't reuse the CURL env var to download sources correctly

### DIFF
--- a/download_files
+++ b/download_files
@@ -244,9 +244,9 @@ for i in *.spec PKGBUILD appimage.yml; do
 
       # avoid re-download if file exists with same modification time and we do not
       # enforce a download via enforceupstream.
-      [ -e "$SRCDIR/$FILE" -a "$ENFORCELOCAL" != "yes" -a "$ENFORCEUPSTREAM" != "yes" ] && CURL=("${CURL[@]}" --time-cond $SRCDIR/$FILE)
+      [ -e "$SRCDIR/$FILE" -a "$ENFORCELOCAL" != "yes" -a "$ENFORCEUPSTREAM" != "yes" ] && CURLCMD=("${CURL[@]}" --time-cond $SRCDIR/$FILE) || CURLCMD=("${CURL[@]}")
 
-      if ! "${CURL[@]}" -R --output "$FILE" "$url"; then
+      if ! "${CURLCMD[@]}" -R --output "$FILE" "$url"; then
         rm -f "$FILE"
         echo "ERROR: Failed to download \"$url\""
         exit 1


### PR DESCRIPTION
This fixes a problem that makes the service sometimes not download all
source files silently.

Since the CURL env var was being reused for every Source file processed,
the curl command was using more and more --time-cond arguments with all
previous existing source files. When one of those source files has a
newer mtime than the requested file, the new file wasn't downloaded.

This was found while trying to debug why if you do:

* osc co mozilla:Factory MozillaFirefox
* cd .../MozillaFirefox
* rm mozilla.keyring
* osc service ra download_files

Then the mozilla.keyring file was not downloaded