### PR TITLE
Download files only on the "last" *.spec files

### DIFF
--- a/download_files
+++ b/download_files
@@ -218,8 +218,17 @@ default_config="/usr/lib/build/configs/sl12.3.conf"
 
 SRCDIR=$PWD
 
+declare -A spec_files
+for i in *.spec; do
+  basespec=$(echo ${i##*:})
+  existing_longest=$(echo ${spec_files[${basespec}]})
+  if [[ ${#i} -gt ${#existing_longest} ]]; then
+    spec_files[${basespec}]=$i
+  fi
+done
+
 RETURN=0
-for i in *.spec PKGBUILD appimage.yml; do
+for i in ${spec_files[@]} PKGBUILD appimage.yml; do
   test -e "$i" || continue
 
   for url in `perl -I/usr/lib/build -MBuild -e Build::show $default_config "$i" sources` `perl -I/usr/lib/build -MBuild -e Build::show $default_config "$i" patches`; do


### PR DESCRIPTION
When executing multiple services, different versions of the same .spec
might be generated. Before this patch, download_files downloaded files
from all of them, which however could cause problems for example for
deb/ubuntu builds that may automatically detect the orig archive (e.g.
if set_version changes the URL to download files from).

This patch fixes the problem by looking at all the *.spec files
referencing the same base spec file and by considering only the longest
file name, because it is the one where the more services were applied.